### PR TITLE
reduce memory usage when computing distance matrix

### DIFF
--- a/Originator/R/originator.R
+++ b/Originator/R/originator.R
@@ -95,8 +95,13 @@ originator <- function(data, query_cell_type, plot = FALSE, output_dir = NA) {
   query_cid <- row.names(temp1[temp1$source == "Query", ])
   
   temp2 <- as.matrix(temp1[, 3:12])
-  temp3 <- as.matrix(dist(temp2))
-  temp4 <- temp3[query_cid, ref_cid]
+  query_umap <- temp2[query_cid, ]
+  ref_umap <- temp2[ref_cid, ]
+  dist_matrix <-
+    sqrt(outer(rowSums(query_umap ^ 2), rowSums(ref_umap ^ 2), "+") - 2 * tcrossprod(query_umap, ref_umap))
+  rownames(dist_matrix) <- query_cid
+  colnames(dist_matrix) <- ref_cid
+  temp4 <- dist_matrix
   
   # Perform clustering
   print("#### Perform clustering")


### PR DESCRIPTION
when originator runs on a large dataset, there is a chance that the built-in function `dist()` has to handle a large matrix and returns a pairwise distance matrix that can barely fit into a small ram. in fact only bipartite distance between query and ref groups is necessary, so by subsetting the matrix and manually calculating the distance, memory usage could be greatly reduced.